### PR TITLE
Nibread interactive

### DIFF
--- a/nibread.c
+++ b/nibread.c
@@ -88,7 +88,6 @@ main(int argc, char *argv[])
 	double st, et;
 	char filename[256], logfilename[256], *dotpos;
 	char argcache[256];
-    char c; /* user input */
 
 	printf(
 		"\nnibread - Commodore 1541/1571 disk image nibbler\n"

--- a/nibread.c
+++ b/nibread.c
@@ -44,6 +44,7 @@ int track_match;
 int gap_match_length;
 int cap_min_ignore;
 int interactive_mode;
+int file_valid;
 int verbose;
 int extended_parallel_test;
 int force_nosync;
@@ -122,6 +123,7 @@ main(int argc, char *argv[])
 	force_density = 0;
 	track_match = 0;
 	interactive_mode = 0;
+    file_valid = 1;
 	verbose = 1;
 	extended_parallel_test = 0;
 	force_nosync = 0;
@@ -384,11 +386,11 @@ main(int argc, char *argv[])
         {
             do {
                 show_menu(filename);
+                file_valid = 1;
                 if (!(  compare_extension(filename, "NIB")
                       || compare_extension(filename, "NB2")
                       || compare_extension(filename, "NBZ"))) {
-                    printf("unsupported file type - only .nib, .nb2 or .nbz allowed!\n");
-                    printf("please enter a valid file name\n");
+                    file_valid = 0;
                     continue;
                 }
                 if(!(disk2file(fd, filename))) {
@@ -480,11 +482,16 @@ static void show_menu(char *filename)
     char input[256];
 
 	printf("\e[1;1H\e[2J\n"); /* clear screen and newline */
-	printf("file name to be written: %s\n\n", filename);
-	printf("Insert disk and enter a command:\n\n");
-	printf("some.txt - changes filename\n");
+    if (file_valid) {
+        printf("file name to be written: %s\n\n", filename);
+        printf("Insert disk and enter a command:\n\n");
+        printf("some.txt - changes filename\n");
+        printf("<enter>: read disk and write to file\n");
+    } else {
+        printf("!! unsupported file type - only .nib, .nb2 or .nbz allowed! !!\n");
+        printf("!!             please enter a valid file name               !!\n\n");
+    }
 	printf("'q'uit - (no need to insert a disk ;-)\n");
-	printf("<enter>: read disk and write to file\n");
 
     fgets(input, sizeof(input), stdin);
     if (strlen(input) <= 1) {

--- a/nibread.c
+++ b/nibread.c
@@ -81,13 +81,14 @@ static int disk2file(CBM_FILE fd, char *filename);
 static void parallel_test(int iterations);
 static void show_menu(char *filename);
 static void next_filename(char *filename);
+static void create_logfile(char *filename, char *argcache);
 
 int ARCH_MAINDECL
 main(int argc, char *argv[])
 {
 	int bump, reset, i;
 	double st, et;
-	char filename[256], logfilename[256], *dotpos;
+	char filename[256];
 	char argcache[256];
 
 	printf(
@@ -328,20 +329,7 @@ main(int argc, char *argv[])
 		TrackAlignmentReport(fd);
 
 	/* create log file */
-	strcpy(logfilename, filename);
-	dotpos = strrchr(logfilename, '.');
-	if (dotpos != NULL)
-		*dotpos = '\0';
-	strcat(logfilename, ".log");
-
-	if ((fplog = fopen(logfilename, "wb")) == NULL)
-	{
-		printf("Couldn't create log file %s!\n", logfilename);
-		exit(2);
-	}
-
-	fprintf(fplog, "%s\n", VERSION);
-	fprintf(fplog, "'%s'\n", argcache);
+    create_logfile(filename, argcache);
 
 	if(strrchr(filename, '.') == NULL)  strcat(filename, ".nbz");
 
@@ -396,7 +384,9 @@ main(int argc, char *argv[])
                 if(!(disk2file(fd, filename))) {
                     printf("Operation failed!\n");
                 } else {
+                    fclose(fplog);
                     next_filename(filename);
+                    create_logfile(filename, argcache);
                 }
             } while(TRUE);
         } else {
@@ -418,6 +408,27 @@ main(int argc, char *argv[])
 	if(fplog) fclose(fplog);
 
 	exit(0);
+}
+
+static void create_logfile(char *filename, char *argcache)
+{
+	char logfilename[256], *dotpos;
+
+	strcpy(logfilename, filename);
+	dotpos = strrchr(logfilename, '.');
+	if (dotpos != NULL)
+		*dotpos = '\0';
+	strcat(logfilename, ".log");
+
+	if ((fplog = fopen(logfilename, "wb")) == NULL)
+	{
+		printf("Couldn't create log file %s!\n", logfilename);
+		exit(2);
+	}
+
+	fprintf(fplog, "%s\n", VERSION);
+	fprintf(fplog, "'%s'\n", argcache);
+
 }
 
 static void next_filename(char *filename)
@@ -498,6 +509,9 @@ static void show_menu(char *filename)
         return;
     }
     if (input[0] == 'q') {
+        if (fplog) {
+            close(fplog);
+        }
         exit(0);
     }
 

--- a/nibtools.h
+++ b/nibtools.h
@@ -112,10 +112,6 @@ extern int backwards;
 /* common */
 void usage(void);
 
-/* nibread.c */
-int disk2file(CBM_FILE fd, char * filename);
-void parallel_test(int interations);
-
 /* nibwrite.c */
 int loadimage(char * filename);
 int writeimage(CBM_FILE fd);


### PR DESCRIPTION
Hi,
I modified the interactive mode for nibread a little :-)
You can see some kind of menu before reading a disk where you can select
* change file name
* quit
* read

So it is possible to read disk23nbz, summer_games_a.nib and then summer_games_b.nib as example.

Also implemented is a search if the given file name contains a number. already. If one is found, this number is taken and increased for the next loop. So if you enter for example
`nibread -I benjo76_disk42.nib`
then it reads the disk into this file and sets the filename for the next disk to `benjo76_disk43.nib`.

Some notes:
- I am on linux only, so there is a chance that there pop up compilation problems on other platforms. I tried to keep my changes similar to the existing content that there should be no problem but I did not test it.
- interactive support for nb2 has been added as a side effect but not tested
- getchar() on linux platforms does not work as one may expect, console input (and output) is buffered; so when you read a character with getchar you 'hang' until you press enter. Then the character is ready to use, but the next time getchar is called you get direct 'enter'... I am not aware of a portable solution for this, so I used fgets instead.
- clear screen is implemented with escape characters which is said to work platform independent, but again: I could not test this.