### PR TITLE
Compile fix for modern header check/guards - nibtools will not compile without defining _DEFAULT_SOURCE

### DIFF
--- a/GNU/Makefile
+++ b/GNU/Makefile
@@ -22,6 +22,7 @@ CBM_WIN_PATH=	../
 
 # Default compile flags.  Be careful with optimization (-O2)
 CFLAGS=${WARNS}
+CFLAGS+=-D_DEFAULT_SOURCE
 #CFLAGS+=-DSVN=$(shell svn info | grep Revision | sed 's/Revision: //') 
 #CFLAGS+=-DSVN=$(shell svnversion | sed -e 's/.*://' -e 's/[A-Z]*$//')
 


### PR DESCRIPTION
PS: I know this is a read-only mirror - but pushing this PR will make it easier to referenceing to this issue on traditional email error reports

/Uffe

Compile fix for modern header check/guards - nibtools will not compile without defining _DEFAULT_SOURCE

Error below:

```
In file included from read.c:12:
read.c: In function ‘TrackAlignmentReport’:
include/LINUX/mnibarch.h:4:19: error: implicit declaration of function ‘usleep’; did you mean ‘sleep’? [-Wimplicit-function-declaration]
    4 | #define delay(x)  usleep((x) * 1000)
      |                   ^~~~~~
read.c:629:33: note: in expansion of macro ‘delay’
  629 |                                 delay(500);
      |                                 ^~~~~
make[2]: *** [<builtin>: read.o] Error 1
```